### PR TITLE
Make openai model to use configurable by `OPENAI_CHAT_MODEL`

### DIFF
--- a/lib/ruboty/openai_chat/actions/base.rb
+++ b/lib/ruboty/openai_chat/actions/base.rb
@@ -35,6 +35,11 @@ module Ruboty
         def pretexts
           [ENV["OPENAI_CHAT_PRETEXT"], memory.namespace(NAMESPACE)[PROFILE_KEY]].compact
         end
+
+        # @return [String]
+        def openai_model
+          ENV["OPENAI_CHAT_MODEL"] || "gpt-3.5-turbo"
+        end
       end
     end
   end

--- a/lib/ruboty/openai_chat/actions/chat.rb
+++ b/lib/ruboty/openai_chat/actions/chat.rb
@@ -36,7 +36,7 @@ module Ruboty
           # https://beta.openai.com/examples/default-chat
           client.chat(
             parameters: {
-              model: "gpt-3.5-turbo",
+              model: openai_model,
               messages: build_messages(human_comment).map(&:to_api_hash),
               temperature: 0.7
             }


### PR DESCRIPTION
This PR allows users to configure OpenAI model by `OPENAI_CHAT_MODEL` (Default: `gpt-3.5-turbo`)

You can see available models here: https://platform.openai.com/docs/models/overview

```console
$ OPENAI_CHAT_MODEL=gpt-4 dotenv bundle exec ./bin/ruboty
Type `exit` or `quit` to end the session.
> ruboty hello
Hello! How can I assist you today?
> ruboty What is your model?
As an artificial intelligence, I don't have a physical model like a car or a phone might. However, you could say my "model" or "version" is based on the latest advancements in machine learning and natural language processing. These technologies enable me to understand and respond to a wide range of human language inputs. How can I assist you further?



$ OPENAI_CHAT_MODEL=gpt-5 dotenv bundle exec ./bin/ruboty
Type `exit` or `quit` to end the session.
> ruboty What is your model?
{
    "error": {
        "message": "The model `gpt-5` does not exist",
        "type": "invalid_request_error",
        "param": null,
        "code": "model_not_found"
    }
}
```